### PR TITLE
Project fix for header/library linking

### DIFF
--- a/example/example.xcodeproj/project.pbxproj
+++ b/example/example.xcodeproj/project.pbxproj
@@ -31446,10 +31446,10 @@
 				HEADER_SEARCH_PATHS = (
 					"$(OF_CORE_HEADERS)",
 					src,
-					$(SRC_ROOT)../../../addons/ofxCGAL/src,
-					$(SRC_ROOT)../../../addons/ofxCGAL/libs/ofxCGAL/include,
-					$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/include,
-					$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/include/eigen3,
+					"$(SRC_ROOT)../../../addons/ofxCGAL/src",
+					"$(SRC_ROOT)../../../addons/ofxCGAL/libs/ofxCGAL/include",
+					"$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/include",
+					"$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/include/eigen3",
 				);
 				ICON = "$(ICON_NAME_DEBUG)";
 				ICON_FILE = "$(ICON_FILE_PATH)$(ICON)";
@@ -31518,9 +31518,9 @@
 					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_50)",
 					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_51)",
 					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_52)",
-					$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/lib/osx/boost,
-					$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/lib/osx/CGAL,
-					$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/lib/osx,
+					"$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/lib/osx/boost",
+					"$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/lib/osx/CGAL",
+					"$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/lib/osx",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)Debug";
 				WRAPPER_EXTENSION = app;
@@ -31542,10 +31542,10 @@
 				HEADER_SEARCH_PATHS = (
 					"$(OF_CORE_HEADERS)",
 					src,
-					$(SRC_ROOT)../../../addons/ofxCGAL/src,
-					$(SRC_ROOT)../../../addons/ofxCGAL/libs/ofxCGAL/include,
-					$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/include,
-					$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/include/eigen3,
+					"$(SRC_ROOT)../../../addons/ofxCGAL/src",
+					"$(SRC_ROOT)../../../addons/ofxCGAL/libs/ofxCGAL/include",
+					"$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/include",
+					"$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/include/eigen3",
 				);
 				ICON = "$(ICON_NAME_RELEASE)";
 				ICON_FILE = "$(ICON_FILE_PATH)$(ICON)";
@@ -31614,9 +31614,9 @@
 					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_49)",
 					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_50)",
 					"$(LIBRARY_SEARCH_PATHS_QUOTED_FOR_TARGET_51)",
-					$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/lib/osx/boost,
-					$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/lib/osx/CGAL,
-					$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/lib/osx,
+					"$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/lib/osx/boost",
+					"$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/lib/osx/CGAL",
+					"$(SRC_ROOT)../../../addons/ofxCGAL/libs/CGAL/lib/osx",
 				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				WRAPPER_EXTENSION = app;


### PR DESCRIPTION
Fix for some direct linking in the project example.
I.E. /Users/Koma/Documents/openFrameworks/of_v0.8.0_osx_release/
to 
$(SRC_ROOT)../../../
